### PR TITLE
Fix Dependabot security alert

### DIFF
--- a/testing/scripts/Cucumber/rome2RioCucumberExample/pom.xml
+++ b/testing/scripts/Cucumber/rome2RioCucumberExample/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updating Junit in pom.xml to 4.13.1, to address Dependabot security alert